### PR TITLE
fix: read returns empty string when reading at end of file

### DIFF
--- a/aaa-stdlib/src/stack.rs
+++ b/aaa-stdlib/src/stack.rs
@@ -484,7 +484,9 @@ impl Stack {
         let result = read(fd as i32, &mut buffer[..]);
 
         match result {
-            Ok(_) => {
+            Ok(bytes_read) => {
+                buffer.truncate(bytes_read);
+
                 let string = String::from_utf8(buffer);
 
                 match string {


### PR DESCRIPTION
Closes #60 