### PR TITLE
fix: highlight keyword `default` in vs code extension

### DIFF
--- a/aaa-vscode-extension/syntaxes/aaa.tmLanguage.json
+++ b/aaa-vscode-extension/syntaxes/aaa.tmLanguage.json
@@ -50,7 +50,7 @@
 		"keywords": {
 			"patterns": [{
 				"name": "keyword.control.aaa",
-				"match": "\\b(if|else|while|fn|as|args|return|import|from|type|struct|foreach|use|const|enum|match|case)\\b"
+				"match": "\\b(if|else|while|fn|as|args|return|import|from|type|struct|foreach|use|const|enum|match|case|default)\\b"
 			}]
 		},
 		"strings": {


### PR DESCRIPTION
Closes #89