### PR TITLE
Fix enum case for variants without values leave Variable::None on stack

### DIFF
--- a/aaa/transpiler/transpiler.py
+++ b/aaa/transpiler/transpiler.py
@@ -366,12 +366,16 @@ class Transpiler:
 
     def _generate_rust_case_block_code(self, case_block: CaseBlock) -> str:
         enum_type = case_block.enum_type
-        variant_id = enum_type.enum_fields[case_block.variant_name][1]
+        variant_type, variant_id = enum_type.enum_fields[case_block.variant_name]
 
         code = self._indent(
             f"{variant_id} => {{ // {enum_type.name}:{case_block.variant_name}\n"
         )
         self.indent_level += 1
+
+        if variant_type is None:
+            code += self._indent("stack.drop();\n")
+
         code += self._generate_rust_function_body(case_block.body)
         self.indent_level -= 1
         code += self._indent("}\n")


### PR DESCRIPTION
Closes #106 